### PR TITLE
Using IEnumerable interface to improve functions performance

### DIFF
--- a/ramon/entry.cs
+++ b/ramon/entry.cs
@@ -1,20 +1,21 @@
 using System;
+using System.Collections.Generic;
 
 public class Program
 {
     static void Main(string[] args)
     {
-        string[] inputArr   = ["SEI", "QUE", "VOCÊ", "VAI", "QUERER", "SER", "UMA", "DE", "NÓS!"];
-        int[] numbers       = [1, 2, 3, 4, 1000];
+        List<string> words = ["SEI", "QUE", "VOCÊ", "VAI", "QUERER", "SER", "UMA", "DE", "NÓS!"];
+        List<int> numbers = [1, 2, 3, 4, 1000];
 
-        string[] test       = Filter(inputArr, target => target == "VAI");
-        int resultInt       = Find(numbers, target => target == 2);
-        int[] newNumbersArr = Map(numbers, target => target * 2);
+        int resultInt = Find(numbers, target => target == 2);
+        List<string> filteredWords = Filter(words, target => target == "VAI").ToList();
+        List<int> processedNumbers = Map(numbers, target => target * 2).ToList();
     }
 
-    private static T? Find<T>(T[] inputArr, Func<T, bool> inputCondition)
+    private static T? Find<T>(List<T> inputList, Func<T, bool> inputCondition)
     {
-        foreach (T currentObj in inputArr)
+        foreach (T currentObj in inputList)
         {
             if (inputCondition(currentObj))
                 return currentObj;
@@ -23,28 +24,20 @@ public class Program
         return default;
     }
 
-    private static T[] Filter<T>(T[] inputArr, Func<T, bool> inputCondition)
+    private static IEnumerable<T> Filter<T>(List<T> inputList, Func<T, bool> inputCondition)
     {
-        var resultArr = Array.Empty<T>();
-
-        foreach (T currentObj in inputArr)
+        foreach (T currentObj in inputList)
         {
             if (inputCondition(currentObj))
-                resultArr = resultArr.Append(currentObj).ToArray();
+                yield return currentObj;
         }
-
-        return resultArr;
     }
 
-    private static T[] Map<T>(T[] inputArr, Func<T, T> inputCondition)
+    private static IEnumerable<T> Map<T>(List<T> inputList, Func<T, T> inputCondition)
     {
-        var resultArr = Array.Empty<T>();
-
-        foreach (T currentObj in inputArr)
+        foreach (T currentObj in inputList)
         {
-            resultArr = resultArr.Append(inputCondition.Invoke(currentObj)).ToArray();
+            yield return inputCondition.Invoke(currentObj);
         }
-
-        return resultArr;
     }
 }


### PR DESCRIPTION
- Usando a instrução "yield" da interface "IEnumerable" para retornar um item por vez, assim removendo a necessidade de coleções auxiliares dentro das funções;
- Substituindo arrays por listas, pela flexibilidade da estrutura.